### PR TITLE
Use dosbox-staging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04 AS base
+FROM ubuntu:24.04 AS base
 
 # Variables for installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -6,11 +6,12 @@ ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV XKB_DEFAULT_RULES=base
 
 # Install dependencies
+RUN echo "deb http://security.ubuntu.com/ubuntu focal-security main universe" > /etc/apt/sources.list.d/ubuntu-focal-sources.list
 RUN apt-get update && \
   echo "tzdata tzdata/Areas select Europe" > ~/tx.txt && \
   echo "tzdata tzdata/Zones/Europe select Berlin" >> ~/tx.txt && \
   debconf-set-selections ~/tx.txt && \
-  apt-get install -y fonts-dejavu-core xfonts-base unzip gnupg apt-transport-https wget software-properties-common novnc websockify libxv1 libglu1-mesa xauth x11-utils xorg libegl1-mesa xauth x11-xkb-utils software-properties-common bzip2 gstreamer1.0-plugins-good gstreamer1.0-pulseaudio gstreamer1.0-tools libglu1-mesa libgtk2.0-0 libncursesw5 libopenal1 libsdl-image1.2 libsdl-ttf2.0-0 libsdl2-2.0 libsndfile1 nginx pulseaudio supervisor ucspi-tcp wget && \
+  apt-get install -y fonts-dejavu-core xfonts-base unzip gnupg apt-transport-https wget software-properties-common novnc websockify libxv1 libglu1-mesa xauth x11-utils xorg libgl1 libglx-mesa0 xauth x11-xkb-utils software-properties-common bzip2 gstreamer1.0-plugins-good gstreamer1.0-pulseaudio gstreamer1.0-tools libglu1-mesa libgtk2.0-0 libncursesw5 libopenal1 libsdl-image1.2 libsdl-ttf2.0-0 libsdl2-2.0 libsndfile1 nginx pulseaudio supervisor ucspi-tcp wget && \
   rm -rf /var/cache/apt/archives /var/lib/apt/lists
 
 # Install VNC server
@@ -40,8 +41,12 @@ ENV DOSBOX_USER=${DOSBOX_USER}
 ARG UID=1000
 ARG GID=1000
 
-RUN groupadd -g ${GID} ${DOSBOX_USER} \
- && useradd -m -u ${UID} -g ${GID} -s /bin/bash ${DOSBOX_USER}
+RUN groupmod --new-name ${DOSBOX_USER} ubuntu
+RUN usermod -d /home/dosbox -m -g ${DOSBOX_USER} -l ${DOSBOX_USER} ubuntu
+
+# RUN deluser --remove-home ubuntu
+# RUN groupadd -g ${GID} ${DOSBOX_USER} \
+#  && useradd -m -u ${UID} -g ${GID} -s /bin/bash ${DOSBOX_USER}
 
 # Per-user dirs + resources
 RUN install -d -o ${DOSBOX_USER} -g ${DOSBOX_USER} \
@@ -104,6 +109,7 @@ RUN sed -i "/import RFB/a \
 ENV SDL_VIDEODRIVER="x11"
 ENV SDL_RENDER_DRIVER="software"
 ENV LIBGL_ALWAYS_SOFTWARE="1"
+ENV SDL_VIDEO_X11_VISUALID=0x022
 
 EXPOSE 80
 WORKDIR /home/${DOSBOX_USER}/dos

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,68 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04 AS base
 
-#User Settings for VNC
-ENV USER=root
-ENV PASSWORD=password1
-
-#Variables for installation
+# Variables for installation
 ENV DEBIAN_FRONTEND=noninteractive
 ENV DEBCONF_NONINTERACTIVE_SEEN=true
 ENV XKB_DEFAULT_RULES=base
 
-#Install dependencies
+# Install dependencies
 RUN apt-get update && \
-  echo "tzdata tzdata/Areas select America" > ~/tx.txt && \
-  echo "tzdata tzdata/Zones/America select New York" >> ~/tx.txt && \
+  echo "tzdata tzdata/Areas select Europe" > ~/tx.txt && \
+  echo "tzdata tzdata/Zones/Europe select Berlin" >> ~/tx.txt && \
   debconf-set-selections ~/tx.txt && \
-  apt-get install -y unzip gnupg apt-transport-https wget software-properties-common novnc websockify libxv1 libglu1-mesa xauth x11-utils xorg tightvncserver libegl1-mesa xauth x11-xkb-utils software-properties-common bzip2 gstreamer1.0-plugins-good gstreamer1.0-pulseaudio gstreamer1.0-tools libglu1-mesa libgtk2.0-0 libncursesw5 libopenal1 libsdl-image1.2 libsdl-ttf2.0-0 libsdl1.2debian libsndfile1 nginx pulseaudio supervisor ucspi-tcp wget build-essential ccache dosbox
+  apt-get install -y fluxbox xfonts-base unzip gnupg apt-transport-https wget software-properties-common novnc websockify libxv1 libglu1-mesa xauth x11-utils xorg libegl1-mesa xauth x11-xkb-utils software-properties-common bzip2 gstreamer1.0-plugins-good gstreamer1.0-pulseaudio gstreamer1.0-tools libglu1-mesa libgtk2.0-0 libncursesw5 libopenal1 libsdl-image1.2 libsdl-ttf2.0-0 libsdl2-2.0 libsndfile1 nginx pulseaudio supervisor ucspi-tcp wget build-essential ccache
+
+# Install VNC server
+RUN wget -q -O- https://packagecloud.io/dcommander/turbovnc/gpgkey | gpg --dearmor > /etc/apt/trusted.gpg.d/TurboVNC.gpg && \
+  wget -q -O /etc/apt/sources.list.d/TurboVNC.list https://raw.githubusercontent.com/TurboVNC/repo/main/TurboVNC.list && \
+  apt-get update && \
+  apt-get install -y turbovnc
+
+FROM base AS dosbox-base
+
+# Dosbox-staging install (tarball)
+ARG DOSBOX_STAGING_VERSION=0.82.2
+RUN set -eux; \
+    cd /tmp; \
+    wget -O ds.tar.xz "https://github.com/dosbox-staging/dosbox-staging/releases/download/v${DOSBOX_STAGING_VERSION}/dosbox-staging-linux-x86_64-v${DOSBOX_STAGING_VERSION}.tar.xz"; \
+    mkdir -p /opt/dosbox-staging; \
+    tar -xJf ds.tar.xz -C /opt/dosbox-staging --strip-components=1; \
+    install -m 0755 /opt/dosbox-staging/dosbox* /usr/local/bin/; \
+    rm -f ds.tar.xz
 
 RUN mkdir ~/.vnc && \
-  mkdir ~/.dosbox
+  mkdir -p ~/.dosbox ~/.config/dosbox
+RUN cp -r /opt/dosbox-staging/resources/glshaders /root/.config/dosbox/
 
-#Copy the files for audio and NGINX
+COPY docker/dosbox.conf /root/.dosbox/dosbox.conf
+
+# Symlink dosbox config for dosbox-staging
+RUN mkdir -p /root/.config/dosbox && \
+    ln -sf /root/.dosbox/dosbox.conf /root/.config/dosbox/dosbox-staging.conf
+
+FROM dosbox-base AS docksbox
+
+# User Settings for VNC
+ENV USER=root
+ENV PASSWORD=password1
+
+# Set VNC password
+RUN mkdir -p /root/.vnc
+RUN printf '%s\n' "$PASSWORD" "$PASSWORD" | /opt/TurboVNC/bin/vncpasswd -f > /root/.vnc/passwd
+RUN chmod 600 /root/.vnc/passwd
+
+# Copy the files for audio and NGINX
 COPY docker/default.pa docker/client.conf /etc/pulse/
 COPY docker/nginx.conf /etc/nginx/
 COPY docker/webaudio.js /usr/share/novnc/core/
-COPY docker/dosbox.conf /root/.dosbox/dosbox.conf
-COPY docker/xstartup /root/.vnc/xstartup
+COPY docker/xstartup.turbovnc /root/.vnc/xsession.sh
+COPY docker/vnc-logs.sh /bin/vnc-logs
 
 # SECURITY: This is a local environment only - do not use in production
-RUN chmod 0777 /root/.vnc/xstartup
+RUN chmod 0777 /root/.vnc/xsession.sh
+RUN chmod 0777 /bin/vnc-logs
 
-#Inject code for audio in the NoVNC client
+# Inject code for audio in the NoVNC client
 RUN sed -i "/import RFB/a \
   import WebAudio from '../core/webaudio.js'" \
   /usr/share/novnc/app/ui.js \
@@ -46,14 +79,18 @@ RUN sed -i "/import RFB/a \
   document.addEventListener('keydown', e => { wa.start(); });" \
   /usr/share/novnc/app/ui.js
 
-RUN echo $PASSWORD | vncpasswd -f > ~/.vnc/passwd && \
-  chmod 0600 ~/.vnc/passwd
+# RUN echo $PASSWORD | vncpasswd -f > ~/.vnc/passwd && \
+#   chmod 0600 ~/.vnc/passwd
 
 COPY keen /dos/keen
 COPY doom /dos/doom
 
 EXPOSE 80
 
-#Copy in supervisor configuration for startup
+ENV SDL_VIDEODRIVER="x11"
+ENV SDL_RENDER_DRIVER="software"
+ENV LIBGL_ALWAYS_SOFTWARE="1"
+
+# Copy in supervisor configuration for startup
 COPY docker/supervisord.conf /etc/supervisor/supervisord.conf
 ENTRYPOINT [ "supervisord", "-c", "/etc/supervisor/supervisord.conf" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,6 +6,7 @@ services:
       - "6080:80"   # browse http://localhost:6080/
     volumes:
       - ./games:/games
+    user: "0:0"
     environment:
       USER: root
       PASSWORD: password1

--- a/docker/dosbox.conf
+++ b/docker/dosbox.conf
@@ -1,28 +1,4 @@
-# This is the configuration file for DOSBox 0.74-3. (Please use the latest version of DOSBox)
-# Lines starting with a # are comment lines and are ignored by DOSBox.
-# They are used to (briefly) document the effect of each option.
-
 [sdl]
-#       fullscreen: Start dosbox directly in fullscreen. (Press ALT-Enter to go back)
-#       fulldouble: Use double buffering in fullscreen. It can reduce screen flickering, but it can also result in a slow DOSBox.
-#   fullresolution: What resolution to use for fullscreen: original, desktop or fixed size (e.g. 1024x768).
-#                     Using your monitor's native resolution (desktop) with aspect=true might give the best results.
-#                     If you end up with small window on a large screen, try an output different from surface.
-#                     On Windows 10 with display scaling (Scale and layout) set to a value above 100%, it is recommended
-#                     to use a lower full/windowresolution, in order to avoid window size problems.
-# windowresolution: Scale the window to this size IF the output device supports hardware scaling.
-#                     (output=surface does not!)
-#           output: What video system to use for output.
-#                   Possible values: surface, overlay, opengl, openglnb.
-#         autolock: Mouse will automatically lock, if you click on the screen. (Press CTRL-F10 to unlock)
-#      sensitivity: Mouse sensitivity.
-#      waitonerror: Wait before closing the console if dosbox has an error.
-#         priority: Priority levels for dosbox. Second entry behind the comma is for when dosbox is not focused/minimized.
-#                     pause is only valid for the second entry.
-#                   Possible values: lowest, lower, normal, higher, highest, pause.
-#       mapperfile: File used to load/save the key/event mappings from. Resetmapper only works with the default value.
-#     usescancodes: Avoid usage of symkeys, might not work on all operating systems.
-
 fullscreen=true
 fulldouble=false
 fullresolution=desktop
@@ -51,38 +27,12 @@ captures=capture
 memsize=16
 
 [render]
-# frameskip: How many frames DOSBox skips before drawing one.
-#    aspect: Do aspect correction, if your output method doesn't support scaling this can slow things down!
-#    scaler: Scaler used to enlarge/enhance low resolution modes. If 'forced' is appended,
-#              then the scaler will be used even if the result might not be desired.
-#              To fit a scaler in the resolution used at full screen may require a border or side bars,
-#              to fill the screen entirely, depending on your hardware, a different scaler/fullresolution might work.
-#            Possible values: none, normal2x, normal3x, advmame2x, advmame3x, advinterp2x, advinterp3x, hq2x, hq3x, 2xsai, super2xsai, supereagle, tv2x, tv3x, rgb2x, rgb3x, scan2x, scan3x.
-
 glshader=none
 frameskip=0
 aspect=true
 scaler=normal2x forced
 
 [cpu]
-#      core: CPU Core used in emulation. auto will switch to dynamic if available and
-#            appropriate.
-#            Possible values: auto, dynamic, normal, simple.
-#   cputype: CPU Type used in emulation. auto is the fastest choice.
-#            Possible values: auto, 386, 386_slow, 486_slow, pentium_slow, 386_prefetch.
-#    cycles: Amount of instructions DOSBox tries to emulate each millisecond.
-#            Setting this value too high results in sound dropouts and lags.
-#            Cycles can be set in 3 ways:
-#              'auto'          tries to guess what a game needs.
-#                              It usually works, but can fail for certain games.
-#              'fixed #number' will set a fixed amount of cycles. This is what you usually
-#                              need if 'auto' fails. (Example: fixed 4000).
-#              'max'           will allocate as much cycles as your computer is able to
-#                              handle.
-#            Possible values: auto, fixed, max.
-#   cycleup: Amount of cycles to decrease/increase with keycombos.(CTRL-F11/CTRL-F12)
-# cycledown: Setting it lower than 100 will be a percentage.
-
 core=auto
 cputype=auto
 cycles=auto
@@ -90,51 +40,17 @@ cycleup=10
 cycledown=20
 
 [mixer]
-#   nosound: Enable silent mode, sound is still emulated though.
-#      rate: Mixer sample rate, setting any device's rate higher than this will probably lower their sound quality.
-#            Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
-# blocksize: Mixer block size, larger blocks might help sound stuttering but sound will also be more lagged.
-#            Possible values: 1024, 2048, 4096, 8192, 512, 256.
-# prebuffer: How many milliseconds of data to keep on top of the blocksize.
-
 nosound=false
 rate=44100
 blocksize=1024
 prebuffer=25
 
 [midi]
-#     mpu401: Type of MPU-401 to emulate.
-#             Possible values: intelligent, uart, none.
-# mididevice: Device that will receive the MIDI data from MPU-401.
-#             Possible values: default, win32, alsa, oss, coreaudio, coremidi, none.
-# midiconfig: Special configuration options for the device driver. This is usually the id of the device you want to use
-#               (find the id with mixer/listmidi).
-#               Or in the case of coreaudio, you can specify a soundfont here.
-#               See the README/Manual for more details.
-
 mpu401=intelligent
 mididevice=default
 midiconfig=
 
 [sblaster]
-#  sbtype: Type of Soundblaster to emulate. gb is Gameblaster.
-#          Possible values: sb1, sb2, sbpro1, sbpro2, sb16, gb, none.
-#  sbbase: The IO address of the soundblaster.
-#          Possible values: 220, 240, 260, 280, 2a0, 2c0, 2e0, 300.
-#     irq: The IRQ number of the soundblaster.
-#          Possible values: 7, 5, 3, 9, 10, 11, 12.
-#     dma: The DMA number of the soundblaster.
-#          Possible values: 1, 5, 0, 3, 6, 7.
-#    hdma: The High DMA number of the soundblaster.
-#          Possible values: 1, 5, 0, 3, 6, 7.
-# sbmixer: Allow the soundblaster mixer to modify the DOSBox mixer.
-# oplmode: Type of OPL emulation. On 'auto' the mode is determined by sblaster type. All OPL modes are Adlib-compatible, except for 'cms'.
-#          Possible values: auto, cms, opl2, dualopl2, opl3, none.
-#  oplemu: Provider for the OPL emulation. compat might provide better quality (see oplrate as well).
-#          Possible values: default, compat, fast.
-# oplrate: Sample rate of OPL music emulation. Use 49716 for highest quality (set the mixer rate accordingly).
-#          Possible values: 44100, 49716, 48000, 32000, 22050, 16000, 11025, 8000.
-
 sbtype=sb16
 sbbase=220
 irq=7
@@ -146,20 +62,6 @@ oplemu=default
 oplrate=44100
 
 [gus]
-#      gus: Enable the Gravis Ultrasound emulation.
-#  gusrate: Sample rate of Ultrasound emulation.
-#           Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
-#  gusbase: The IO base address of the Gravis Ultrasound.
-#           Possible values: 240, 220, 260, 280, 2a0, 2c0, 2e0, 300.
-#   gusirq: The IRQ number of the Gravis Ultrasound.
-#           Possible values: 5, 3, 7, 9, 10, 11, 12.
-#   gusdma: The DMA channel of the Gravis Ultrasound.
-#           Possible values: 3, 0, 1, 5, 6, 7.
-# ultradir: Path to Ultrasound directory. In this directory
-#           there should be a MIDI directory that contains
-#           the patch files for GUS playback. Patch sets used
-#           with Timidity should work fine.
-
 gus=false
 gusrate=44100
 gusbase=240
@@ -168,15 +70,6 @@ gusdma=3
 ultradir=C:\ULTRASND
 
 [speaker]
-# pcspeaker: Enable PC-Speaker emulation.
-#    pcrate: Sample rate of the PC-Speaker sound generation.
-#            Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
-#     tandy: Enable Tandy Sound System emulation. For 'auto', emulation is present only if machine is set to 'tandy'.
-#            Possible values: auto, on, off.
-# tandyrate: Sample rate of the Tandy 3-Voice generation.
-#            Possible values: 44100, 48000, 32000, 22050, 16000, 11025, 8000, 49716.
-#    disney: Enable Disney Sound Source emulation. (Covox Voice Master and Speech Thing compatible).
-
 pcspeaker=true
 pcrate=44100
 tandy=auto
@@ -184,20 +77,6 @@ tandyrate=44100
 disney=true
 
 [joystick]
-# joysticktype: Type of joystick to emulate: auto (default), none,
-#               2axis (supports two joysticks),
-#               4axis (supports one joystick, first joystick used),
-#               4axis_2 (supports one joystick, second joystick used),
-#               fcs (Thrustmaster), ch (CH Flightstick).
-#               none disables joystick emulation.
-#               auto chooses emulation depending on real joystick(s).
-#               (Remember to reset dosbox's mapperfile if you saved it earlier)
-#               Possible values: auto, 2axis, 4axis, 4axis_2, fcs, ch, none.
-#        timed: enable timed intervals for axis. Experiment with this option, if your joystick drifts (away).
-#     autofire: continuously fires as long as you keep the button pressed.
-#       swap34: swap the 3rd and the 4th axis. Can be useful for certain joysticks.
-#   buttonwrap: enable button wrapping at the number of emulated buttons.
-
 joysticktype=auto
 timed=true
 autofire=false
@@ -205,47 +84,21 @@ swap34=false
 buttonwrap=false
 
 [serial]
-# serial1: set type of device connected to com port.
-#          Can be disabled, dummy, modem, nullmodem, directserial.
-#          Additional parameters must be in the same line in the form of
-#          parameter:value. Parameter for all types is irq (optional).
-#          for directserial: realport (required), rxdelay (optional).
-#                           (realport:COM1 realport:ttyS0).
-#          for modem: listenport (optional).
-#          for nullmodem: server, rxdelay, txdelay, telnet, usedtr,
-#                         transparent, port, inhsocket (all optional).
-#          Example: serial1=modem listenport:5000
-#          Possible values: dummy, disabled, modem, nullmodem, directserial.
-# serial2: see serial1
-#          Possible values: dummy, disabled, modem, nullmodem, directserial.
-# serial3: see serial1
-#          Possible values: dummy, disabled, modem, nullmodem, directserial.
-# serial4: see serial1
-#          Possible values: dummy, disabled, modem, nullmodem, directserial.
-
 serial1=dummy
 serial2=dummy
 serial3=disabled
 serial4=disabled
 
 [dos]
-#            xms: Enable XMS support.
-#            ems: Enable EMS support.
-#            umb: Enable UMB support.
-# keyboardlayout: Language code of the keyboard layout (or none).
-
 xms=true
 ems=true
 umb=true
 keyboardlayout=auto
 
 [ipx]
-# ipx: Enable ipx over UDP/IP emulation.
-
 ipx=true
 
 [autoexec]
-# Lines in this section will be run at startup.
-# You can put your MOUNT lines here.
-
-
+@MOUNT C /home/dosbox/dos
+C:
+@IF EXIST C:\autoexec.bat CALL C:\autoexec.bat

--- a/docker/dosbox.conf
+++ b/docker/dosbox.conf
@@ -59,6 +59,7 @@ memsize=16
 #              to fill the screen entirely, depending on your hardware, a different scaler/fullresolution might work.
 #            Possible values: none, normal2x, normal3x, advmame2x, advmame3x, advinterp2x, advinterp3x, hq2x, hq3x, 2xsai, super2xsai, supereagle, tv2x, tv3x, rgb2x, rgb3x, scan2x, scan3x.
 
+glshader=none
 frameskip=0
 aspect=true
 scaler=normal2x forced

--- a/docker/dosbox.conf
+++ b/docker/dosbox.conf
@@ -12,16 +12,8 @@ mapperfile=mapper-0.74-3.map
 usescancodes=false
 
 [dosbox]
-# language: Select another language file.
-#  machine: The type of machine DOSBox tries to emulate.
-#           Possible values: hercules, cga, tandy, pcjr, ega, vgaonly, svga_s3, svga_et3000, svga_et4000, svga_paradise, vesa_nolfb, vesa_oldvbe.
-# captures: Directory where things like wave, midi, screenshot get captured.
-#  memsize: Amount of memory DOSBox has in megabytes.
-#             This value is best left at its default to avoid problems with some games,
-#             though few games might require a higher value.
-#             There is generally no speed advantage when raising this value.
-
-language=
+automount=true
+language=en
 machine=svga_s3
 captures=capture
 memsize=16
@@ -31,6 +23,7 @@ glshader=none
 frameskip=0
 aspect=true
 scaler=normal2x forced
+glshader=crt-auto
 
 [cpu]
 core=auto
@@ -99,6 +92,6 @@ keyboardlayout=auto
 ipx=true
 
 [autoexec]
-@MOUNT C /home/dosbox/dos
+# @MOUNT C /home/dosbox/dos
 C:
 @IF EXIST C:\autoexec.bat CALL C:\autoexec.bat

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -41,3 +41,11 @@ numprocs=1
 startsecs=0
 stdout_logfile=/root/nginx.log
 
+[program:fix-home-ownership]
+command=/bin/sh -c 'find /home/${DOSBOX_USER} \( \! -user ${DOSBOX_USER} -o \! -group ${DOSBOX_USER} \) -print0 | xargs -0r chown ${DOSBOX_USER}:${DOSBOX_USER} && chmod g+s /home/${DOSBOX_USER}'
+priority=1
+autostart=true
+autorestart=false
+startsecs=0
+stdout_logfile=/var/log/supervisor/fix-home-ownership.log
+stderr_logfile=/var/log/supervisor/fix-home-ownership.err

--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -1,11 +1,15 @@
 [supervisord]
+user=root
 nodaemon=true
 pidfile=/root/supervisord.pid
 logfile=/root/supervisord.log
 
 [program:vncserver]
-command=bash -c '/usr/bin/rm -rf /tmp/.X11-unix && /usr/bin/rm -rf /tmp/.X1-lock && rm ~/.vnc/passwd && echo $PASSWORD | vncpasswd -f > ~/.vnc/passwd && chmod 0600 ~/.vnc/passwd && vncserver'
-stdout_logfile=/root/x11vnc.log
+# command=/opt/TurboVNC/bin/vncserver :1 -fg -geometry 1280x800 -localhost -AlwaysShared -SecurityTypes VNC -rfbauth /root/.vnc/passwd -xstartup /root/.vnc/xsession.sh
+command=/opt/TurboVNC/bin/vncserver :1 -fg -geometry 1280x800 -localhost -AlwaysShared -SecurityTypes None -xstartup /root/.vnc/xsession.sh
+autorestart=true
+priority=20
+# stdout_logfile=/root/x11vnc.log
 redirect_stderr=true
 
 [program:websockify_vnc]
@@ -36,3 +40,4 @@ startretries=5
 numprocs=1
 startsecs=0
 stdout_logfile=/root/nginx.log
+

--- a/docker/vnc-logs.sh
+++ b/docker/vnc-logs.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+cat /root/.vnc/*:*.log

--- a/docker/xstartup
+++ b/docker/xstartup
@@ -1,3 +1,0 @@
-#!/bin/sh
-# Command to start DOSBox
-dosbox -conf ~/.dosbox/dosbox.conf -c "MOUNT C: /dos" -c 'C:' &

--- a/docker/xstartup.turbovnc
+++ b/docker/xstartup.turbovnc
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -eu
+
+# Log and use whatever DISPLAY vncserver passed in
+echo "xstartup: DISPLAY=${DISPLAY}" >&2
+
+# Wait until X is actually accepting connections
+for i in $(seq 1 50); do
+  xdpyinfo >/dev/null 2>&1 && break
+  sleep 0.1
+done
+
+# Keep the session alive (foreground)
+# exec /usr/bin/fluxbox
+
+# # run dosbox-staging; keep session alive if it exits
+DBIN="$(command -v dosbox-staging || command -v dosbox)"
+while true; do
+  "$DBIN" -conf /root/.config/dosbox/dosbox-staging.conf
+  echo "DOSBox exite[d; restarting in 2s..." >&2
+  sleep 2
+done

--- a/docker/xstartup.turbovnc
+++ b/docker/xstartup.turbovnc
@@ -1,22 +1,37 @@
 #!/bin/sh
 set -eu
 
-# Log and use whatever DISPLAY vncserver passed in
 echo "xstartup: DISPLAY=${DISPLAY}" >&2
 
-# Wait until X is actually accepting connections
-for i in $(seq 1 50); do
-  xdpyinfo >/dev/null 2>&1 && break
-  sleep 0.1
-done
+# Wait until X is up
+for i in $(seq 1 50); do xdpyinfo >/dev/null 2>&1 && break; sleep 0.1; done
 
-# Keep the session alive (foreground)
-# exec /usr/bin/fluxbox
+# Who runs DOSBox (fallback if not set)
+DOSBOX_USER="${DOSBOX_USER:-dosbox}"
 
-# # run dosbox-staging; keep session alive if it exits
+# 1) Give DOSBOX_USER the X cookie from the VNC server (root's .Xauthority)
+#    Robust: extract/merge only the needed entry for $DISPLAY.
+if [ -r "${XAUTHORITY:-/root/.Xauthority}" ]; then
+  XAUTH_SRC="${XAUTHORITY:-/root/.Xauthority}"
+  su -s /bin/sh - "${DOSBOX_USER}" -c '
+    set -eu
+    mkdir -p "$HOME"
+    touch "$HOME/.Xauthority"
+  '
+  # extract from root -> merge into user
+  xauth -f "$XAUTH_SRC" nextract - "$DISPLAY" \
+    | su -s /bin/sh - "${DOSBOX_USER}" -c 'xauth -f "$HOME/.Xauthority" nmerge - >/dev/null 2>&1 || true'
+fi
+
+# Optional fallback (looser): allow the local user via xhost.
+# xhost +SI:localuser:$DOSBOX_USER || true
+
+# 2) Run DOSBox forever as DOSBOX_USER, with safe software video
 DBIN="$(command -v dosbox-staging || command -v dosbox)"
+CONF="/home/${DOSBOX_USER}/.config/dosbox/dosbox.conf"
+
 while true; do
-  "$DBIN" -conf /root/.config/dosbox/dosbox-staging.conf
-  echo "DOSBox exite[d; restarting in 2s..." >&2
+  su -s /bin/sh -c "exec '${DBIN}' -conf '${CONF}'" ${DOSBOX_USER}
+  echo "DOSBox exited; restarting in 2s..." >&2
   sleep 2
 done


### PR DESCRIPTION
This pull request refactors and modernizes the Docker-based DOSBox environment, focusing on improved user separation, updated VNC server integration, and enhanced configuration management. The changes introduce a multi-stage Docker build, switch to TurboVNC for VNC support, and move to per-user DOSBox configuration and demo data handling. Additionally, the DOSBox configuration is cleaned up, and startup scripts are made more robust.

**Dockerfile and build process modernization:**

* Refactored `Dockerfile` to use multi-stage builds, added TurboVNC installation, and separated DOSBox user setup from root, enabling cleaner user separation and easier volume mapping. Demo data (`keen`, `doom`) is now copied to the per-user DOS directory, and environment variables for SDL and LIBGL are set for software rendering. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R1) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L14-R82) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L49-R120)

**VNC integration and startup improvements:**

* Switched from TightVNC to TurboVNC, updated VNC password handling, and replaced the legacy `xstartup` script with a more robust `xsession.sh` that correctly manages X11 authentication for the DOSBox user. Supervisor configuration is updated to launch TurboVNC with improved options and error handling. [[1]](diffhunk://#diff-999cc2b925d56d3e59d0a7153fdd9d466b0b61205c9f767aadafcbad79cc0804R2-R12) [[2]](diffhunk://#diff-3bd6a69650c49d582f1a3e434834a254b720c94b8f5d1156ec202ced91890375R1-R37)

**DOSBox configuration and user data handling:**

* Cleaned up and modernized `docker/dosbox.conf`, removing outdated comments, setting up auto-mount of the DOS directory, and ensuring per-user configuration and demo data placement. [[1]](diffhunk://#diff-dabb426932686ff40d9989f068906386bdd0505740d921022911368732fbd8e2L1-L25) [[2]](diffhunk://#diff-dabb426932686ff40d9989f068906386bdd0505740d921022911368732fbd8e2L54-L136) [[3]](diffhunk://#diff-dabb426932686ff40d9989f068906386bdd0505740d921022911368732fbd8e2L148-L161) [[4]](diffhunk://#diff-dabb426932686ff40d9989f068906386bdd0505740d921022911368732fbd8e2L170-R104)

**docker-compose and permissions:**

* Updated `docker-compose.yaml` to run the container as root (`user: "0:0"`) for compatibility with the new VNC and DOSBox setup.

**Auxiliary scripts and cleanup:**

* Added a new script `docker/vnc-logs.sh` for easier access to VNC logs, and removed obsolete scripts such as the old `docker/xstartup`. [[1]](diffhunk://#diff-2d0c83cd7d0f677ffcdfec70a6c1d70ec34be8fd2aa7b71af0eb33b54705069bR1-R3) [[2]](diffhunk://#diff-5ae91ada2ea08840e238eb5134481d44cbe45d03c1310e3af35d7ec13e559663L1-L3)